### PR TITLE
Resolves #10 and #8, deploy to AWS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,9 +68,9 @@ jobs:
             
             sudo systemctl start docker
             
-            sudo docker stop weather_planner_app
-            sudo docker rm weather_planner_app
-            sudo docker rmi ${{ env.DOCKER_IMAGE }}
+            sudo docker stop weather_planner_app || True
+            sudo docker rm weather_planner_app || True
+            sudo docker rmi ${{ env.DOCKER_IMAGE }} || True
             
             sudo docker pull ${{ env.DOCKER_IMAGE }}:latest
             


### PR DESCRIPTION
Deploys the docker image to AWS. A few things are clunky, such as reinstalling Docker each time, but we can see that the image is pulled onto the server and the container is run. More work is needed, hence not merging to main, but would make sense to work on this now with the rest of the github actions items rather than a separate branch.

Note: currently the .yml file will stop Docker as soon as it successfully runs the updated container. This is because I don't want the AWS server constantly running while we work on this, but this can be removed easily by removing the last two lines of the .yml when we are ready

Note(!!): the AWS secrets are managed in Github secrets in the devtest environment. I am not sure that this is correct, so please triple check me that I am not exposing our API keys.